### PR TITLE
feat(skeleton): skeleton 컴포넌트 구현

### DIFF
--- a/packages/skeleton/.storybook/main.ts
+++ b/packages/skeleton/.storybook/main.ts
@@ -1,0 +1,16 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+export default {
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  addons: [
+    '@storybook/addon-onboarding',
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@chromatic-com/storybook',
+    '@storybook/addon-interactions',
+  ],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+} satisfies StorybookConfig;

--- a/packages/skeleton/.storybook/preview.ts
+++ b/packages/skeleton/.storybook/preview.ts
@@ -1,0 +1,5 @@
+import type { Preview } from '@storybook/react';
+
+export default {
+  tags: ['autodocs'],
+} satisfies Preview;

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@sipe-team/typography",
-  "description": "Typography component for Sipe Design System",
+  "name": "@sipe-team/skeleton",
+  "description": "Skeleton component for Sipe Design System",
   "version": "0.0.0",
   "license": "MIT",
   "repository": {
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -9,7 +9,9 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -21,6 +23,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",
+    "@faker-js/faker": "^9.2.0",
     "@storybook/addon-essentials": "catalog:",
     "@storybook/addon-interactions": "catalog:",
     "@storybook/addon-links": "catalog:",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -9,7 +9,9 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -28,6 +30,8 @@
     "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
     "@types/react": "^18.3.12",
     "happy-dom": "catalog:",
     "react": "^18.3.1",
@@ -54,5 +58,8 @@
       }
     }
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0"
+  }
 }

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@sipe-team/typography",
+  "description": "Typography component for Sipe Design System",
+  "version": "0.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sipe-team/3-1_sds"
+  },
+  "type": "module",
+  "exports": "./src/index.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "build:storybook": "storybook build",
+    "dev:storybook": "storybook dev -p 6006",
+    "lint": "biome lint .",
+    "test": "vitest",
+    "typecheck": "tsc",
+    "prepack": "pnpm run build"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@storybook/addon-essentials": "catalog:",
+    "@storybook/addon-interactions": "catalog:",
+    "@storybook/addon-links": "catalog:",
+    "@storybook/blocks": "catalog:",
+    "@storybook/react": "catalog:",
+    "@storybook/react-vite": "catalog:",
+    "@storybook/test": "catalog:",
+    "@types/react": "^18.3.12",
+    "happy-dom": "catalog:",
+    "react": "^18.3.1",
+    "storybook": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "react": ">= 18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
+  },
+  "sideEffects": false
+}

--- a/packages/skeleton/src/Skeleton.module.css
+++ b/packages/skeleton/src/Skeleton.module.css
@@ -1,0 +1,19 @@
+@keyframes fadeInOut {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.8;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+
+.skeleton{
+  animation: fadeInOut 1.5s infinite;
+  width: var(--width);
+  height: var(--height);
+  background-color: rgb(155, 155, 155);
+}

--- a/packages/skeleton/src/Skeleton.module.css
+++ b/packages/skeleton/src/Skeleton.module.css
@@ -12,8 +12,19 @@
 
 
 .skeleton{
-  animation: fadeInOut 1.5s infinite;
+  animation: fadeInOut 1.5s infinite !important;
   width: var(--width);
   height: var(--height);
   background-color: rgb(155, 155, 155);
+
+  background-image: none !important;
+  background-clip: border-box !important;
+  border: none !important;
+  box-shadow: none !important;
+  box-decoration-break: clone !important;
+  color: transparent !important;
+  outline: none !important;
+  pointer-events: none !important;
+  user-select: none !important;
+  cursor: default !important;
 }

--- a/packages/skeleton/src/Skeleton.stories.tsx
+++ b/packages/skeleton/src/Skeleton.stories.tsx
@@ -1,0 +1,70 @@
+// Skeleton.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { Skeleton } from './Skeleton';
+
+const meta = {
+  component: Skeleton,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['circle', 'rectangular'],
+    },
+    width: {
+      control: { type: 'number', min: 20, max: 200, step: 10 },
+    },
+    height: {
+      control: { type: 'number', min: 20, max: 200, step: 10 },
+    },
+    loading: {
+      control: 'boolean',
+    },
+    asChild: {
+      control: 'boolean',
+    },
+  },
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    loading: true,
+    variant: 'rectangular',
+    width: 100,
+    height: 100,
+  },
+};
+
+export const CircleSkeleton: Story = {
+  args: {
+    loading: true,
+    variant: 'circle',
+    width: 80,
+    height: 80,
+  },
+};
+
+export const RectangularSkeleton: Story = {
+  args: {
+    loading: true,
+    variant: 'rectangular',
+    width: 80,
+    height: 30,
+  },
+};
+
+export const SkeletonWithChildren: Story = {
+  args: {
+    loading: true,
+    asChild: true,
+    children: <button type="button">Loading...</button>,
+    variant: 'rectangular',
+    width: 120,
+    height: 50,
+  },
+};

--- a/packages/skeleton/src/Skeleton.stories.tsx
+++ b/packages/skeleton/src/Skeleton.stories.tsx
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 // Skeleton.stories.tsx
 import type { Meta, StoryObj } from '@storybook/react';
 import { Skeleton } from './Skeleton';
@@ -71,14 +72,7 @@ export const SkeletonWithText: Story = {
   args: {
     loading: true,
     asChild: true,
-    children: (
-      <span>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Debitis enim
-        labore quibusdam in officia id veniam assumenda ut, accusamus, officiis
-        consectetur minima dolorum facere minus, corrupti corporis. Esse, dolor
-        magni?
-      </span>
-    ),
+    children: <span>{faker.lorem.lines(2)}</span>,
     variant: 'rectangular',
   },
 };

--- a/packages/skeleton/src/Skeleton.stories.tsx
+++ b/packages/skeleton/src/Skeleton.stories.tsx
@@ -66,3 +66,19 @@ export const SkeletonWithChildren: Story = {
     variant: 'rectangular',
   },
 };
+
+export const SkeletonWithText: Story = {
+  args: {
+    loading: true,
+    asChild: true,
+    children: (
+      <span>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Debitis enim
+        labore quibusdam in officia id veniam assumenda ut, accusamus, officiis
+        consectetur minima dolorum facere minus, corrupti corporis. Esse, dolor
+        magni?
+      </span>
+    ),
+    variant: 'rectangular',
+  },
+};

--- a/packages/skeleton/src/Skeleton.stories.tsx
+++ b/packages/skeleton/src/Skeleton.stories.tsx
@@ -64,7 +64,5 @@ export const SkeletonWithChildren: Story = {
     asChild: true,
     children: <button type="button">Loading...</button>,
     variant: 'rectangular',
-    width: 120,
-    height: 50,
   },
 };

--- a/packages/skeleton/src/Skeleton.test.tsx
+++ b/packages/skeleton/src/Skeleton.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { Skeleton } from './Skeleton';
+
+test('loading이 true 일 때 스켈레톤이 렌더링 된다.', () => {
+  render(<Skeleton loading={true} data-testid="skeleton" />);
+
+  const skeleton = screen.getByTestId('skeleton');
+  expect(skeleton).toBeInTheDocument();
+});
+
+test('loading이 false 일 때 children이 렌더링 된다.', () => {
+  render(<Skeleton loading={false}>Childrun</Skeleton>);
+
+  expect(screen.getByText('Childrun')).toBeInTheDocument();
+});
+
+test('variant가 circle일 때 borderRadius가 50%로 설정된다.', () => {
+  render(<Skeleton loading={true} variant="circle" data-testid="skeleton" />);
+
+  const skeleton = screen.getByTestId('skeleton');
+  expect(skeleton).toHaveStyle({ borderRadius: '50%' });
+});
+test('variant가 rectangular일 때 borderRadius가 기본값으로 설정된다.', () => {
+  render(
+    <Skeleton loading={true} variant="rectangular" data-testid="skeleton" />,
+  );
+
+  const skeleton = screen.getByTestId('skeleton');
+  expect(skeleton).toHaveStyle({ borderRadius: '4px' });
+});
+test('width와 height가 props로 전달될 때 올바르게 스타일이 적용된다.', () => {
+  render(
+    <Skeleton loading={true} width={150} height={50} data-testid="skeleton" />,
+  );
+
+  const skeleton = screen.getByTestId('skeleton');
+  expect(skeleton).toHaveStyle({ '--width': '150px', '--height': '50px' });
+});
+
+test('asChild가 true일 때 Slot 컴포넌트가 사용된다.', () => {
+  render(
+    <Skeleton asChild loading={true} width={120} height={30}>
+      <span data-testid="child">Child Content</span>
+    </Skeleton>,
+  );
+
+  const child = screen.getByTestId('child');
+  expect(child).toBeInTheDocument();
+  expect(child).toHaveStyle({
+    'background-color': 'rgb(155, 155, 155)',
+    '--width': '120px',
+    '--height': '30px',
+  });
+});

--- a/packages/skeleton/src/Skeleton.test.tsx
+++ b/packages/skeleton/src/Skeleton.test.tsx
@@ -3,9 +3,9 @@ import { expect, test } from 'vitest';
 import { Skeleton } from './Skeleton';
 
 test('loading이 true 일 때 스켈레톤이 렌더링 된다.', () => {
-  render(<Skeleton loading={true} data-testid="skeleton" />);
+  render(<Skeleton loading={true} aria-label="skeleton" />);
 
-  const skeleton = screen.getByTestId('skeleton');
+  const skeleton = screen.getByLabelText('skeleton');
   expect(skeleton).toBeInTheDocument();
 });
 
@@ -16,29 +16,29 @@ test('loading이 false 일 때 children이 렌더링 된다.', () => {
 });
 
 test('variant가 circle일 때 borderRadius가 50%로 설정된다.', () => {
-  render(<Skeleton loading={true} variant="circle" data-testid="skeleton" />);
+  render(<Skeleton loading={true} variant="circle" aria-label="skeleton" />);
 
-  const skeleton = screen.getByTestId('skeleton');
+  const skeleton = screen.getByLabelText('skeleton');
   expect(skeleton).toHaveStyle({ borderRadius: '50%' });
 });
-test('variant가 rectangular일 때 borderRadius가 기본값으로 설정된다.', () => {
+test('variant가 rectangular일 때 borderRadius가 기본값 4px으로 설정된다.', () => {
   render(
-    <Skeleton loading={true} variant="rectangular" data-testid="skeleton" />,
+    <Skeleton loading={true} variant="rectangular" aria-label="skeleton" />,
   );
 
-  const skeleton = screen.getByTestId('skeleton');
+  const skeleton = screen.getByLabelText('skeleton');
   expect(skeleton).toHaveStyle({ borderRadius: '4px' });
 });
 test('width와 height가 props로 전달될 때 올바르게 스타일이 적용된다.', () => {
   render(
-    <Skeleton loading={true} width={150} height={50} data-testid="skeleton" />,
+    <Skeleton loading={true} width={150} height={50} aria-label="skeleton" />,
   );
 
-  const skeleton = screen.getByTestId('skeleton');
-  expect(skeleton).toHaveStyle({ '--width': '150px', '--height': '50px' });
+  const skeleton = screen.getByLabelText('skeleton');
+  expect(skeleton).toHaveStyle({ width: '150px', height: '50px' });
 });
 
-test('asChild가 true일 때 Slot 컴포넌트가 사용된다.', () => {
+test('asChild가 true일 때, children으로 전달된 요소에 Skeleton 스타일을 적용한다.', () => {
   render(
     <Skeleton asChild loading={true} width={120} height={30}>
       <span data-testid="child">Child Content</span>
@@ -49,7 +49,7 @@ test('asChild가 true일 때 Slot 컴포넌트가 사용된다.', () => {
   expect(child).toBeInTheDocument();
   expect(child).toHaveStyle({
     'background-color': 'rgb(155, 155, 155)',
-    '--width': '120px',
-    '--height': '30px',
+    width: '120px',
+    height: '30px',
   });
 });

--- a/packages/skeleton/src/Skeleton.tsx
+++ b/packages/skeleton/src/Skeleton.tsx
@@ -7,12 +7,6 @@ import {
 } from 'react';
 import styles from './Skeleton.module.css';
 
-const DEFAUT_SIZE = {
-  WIDTH: 100,
-  HEIGHT: 20,
-  RADIUS: 4,
-} as const;
-
 type Variant = 'circle' | 'rectangular';
 
 interface SkeletonProps extends ComponentProps<'div'> {
@@ -31,10 +25,9 @@ export const Skeleton = forwardRef(function Skeleton(
   const Component = asChild ? Slot : 'div';
 
   const style = {
-    '--width': props.width ? `${props.width}px` : `${DEFAUT_SIZE.WIDTH}px`,
-    '--height': props.height ? `${props.height}px` : `${DEFAUT_SIZE.HEIGHT}px`,
-    borderRadius:
-      props.variant === 'circle' ? '50%' : `${DEFAUT_SIZE.RADIUS}px`,
+    '--width': props.width ? `${props.width}px` : 'auto',
+    '--height': props.height ? `${props.height}px` : 'auto',
+    borderRadius: props.variant === 'circle' ? '50%' : '4px',
   } as CSSProperties;
 
   return (

--- a/packages/skeleton/src/Skeleton.tsx
+++ b/packages/skeleton/src/Skeleton.tsx
@@ -1,0 +1,46 @@
+import { Slot } from '@radix-ui/react-slot';
+import {
+  type CSSProperties,
+  type ComponentProps,
+  type ForwardedRef,
+  forwardRef,
+} from 'react';
+import styles from './Skeleton.module.css';
+
+const DEFAUT_SIZE = {
+  WIDTH: 100,
+  HEIGHT: 20,
+  RADIUS: 4,
+} as const;
+
+type Variant = 'circle' | 'rectangular';
+
+interface SkeletonProps extends ComponentProps<'div'> {
+  asChild?: boolean;
+  loading: boolean;
+  variant?: Variant;
+  width?: number;
+  height?: number;
+}
+export const Skeleton = forwardRef(function Skeleton(
+  { asChild, loading, children, ...props }: SkeletonProps,
+  ref: ForwardedRef<any>,
+) {
+  if (!loading) return children;
+
+  const Component = asChild ? Slot : 'div';
+
+  const style = {
+    '--width': props.width ? `${props.width}px` : `${DEFAUT_SIZE.WIDTH}px`,
+    '--height': props.height ? `${props.height}px` : `${DEFAUT_SIZE.HEIGHT}px`,
+    borderRadius:
+      props.variant === 'circle' ? '50%' : `${DEFAUT_SIZE.RADIUS}px`,
+  } as CSSProperties;
+
+  return (
+    <Component ref={ref} {...props} style={style} className={styles.skeleton}>
+      {children}
+    </Component>
+  );
+});
+Skeleton.displayName = 'Skeleton';

--- a/packages/skeleton/src/env.d.ts
+++ b/packages/skeleton/src/env.d.ts
@@ -1,0 +1,1 @@
+declare module '*.module.css';

--- a/packages/skeleton/src/index.ts
+++ b/packages/skeleton/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Skeleton';

--- a/packages/skeleton/tsconfig.json
+++ b/packages/skeleton/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/skeleton/tsup.config.ts
+++ b/packages/skeleton/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  clean: true,
+  dts: true,
+  format: ['esm', 'cjs'],
+});

--- a/packages/skeleton/vitest.config.ts
+++ b/packages/skeleton/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    globals: true,
+    passWithNoTests: true,
+    setupFiles: './vitest.setup.ts',
+    watch: false,
+    css: true,
+  },
+});

--- a/packages/skeleton/vitest.setup.ts
+++ b/packages/skeleton/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,64 @@ importers:
         specifier: 'catalog:'
         version: 2.1.4(@types/node@22.8.1)(happy-dom@15.7.4)
 
+  packages/skeleton:
+    dependencies:
+      '@radix-ui/react-slot':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react@18.3.12)(react@18.3.1)
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 1.9.4
+      '@storybook/addon-essentials':
+        specifier: 'catalog:'
+        version: 8.3.6(storybook@8.3.6)
+      '@storybook/addon-interactions':
+        specifier: 'catalog:'
+        version: 8.3.6(storybook@8.3.6)
+      '@storybook/addon-links':
+        specifier: 'catalog:'
+        version: 8.3.6(react@18.3.1)(storybook@8.3.6)
+      '@storybook/blocks':
+        specifier: 'catalog:'
+        version: 8.3.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)
+      '@storybook/react':
+        specifier: 'catalog:'
+        version: 8.3.6(@storybook/test@8.3.6(storybook@8.3.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)(typescript@5.6.3)
+      '@storybook/react-vite':
+        specifier: 'catalog:'
+        version: 8.3.6(@storybook/test@8.3.6(storybook@8.3.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.2)(storybook@8.3.6)(typescript@5.6.3)(vite@5.4.10(@types/node@22.8.1))
+      '@storybook/test':
+        specifier: 'catalog:'
+        version: 8.3.6(storybook@8.3.6)
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: ^16.0.1
+        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.12
+      happy-dom:
+        specifier: 'catalog:'
+        version: 15.7.4
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      storybook:
+        specifier: 'catalog:'
+        version: 8.3.6
+      tsup:
+        specifier: 'catalog:'
+        version: 8.3.5(jiti@2.3.3)(postcss@8.4.47)(typescript@5.6.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.6.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.4(@types/node@22.8.1)(happy-dom@15.7.4)
+
   packages/typography:
     dependencies:
       '@radix-ui/react-slot':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 1.9.4
+      '@faker-js/faker':
+        specifier: ^9.2.0
+        version: 9.2.0
       '@storybook/addon-essentials':
         specifier: 'catalog:'
         version: 8.3.6(storybook@8.3.6)


### PR DESCRIPTION
## 변경사항
loading 중임을 알려주는 UX 컴포넌트 인 Skeleton 입니다.
radix ui를 참고하여 기본적으로 사이즈와 variant로 모양을 만들 수 있으며, 텍스트를 자식 컴포넌트에 입력 시 해당 크기에 맞는 컴포넌트 사이즈를 만듭니다.
radix에서는 글자색을 parent의 color를 사용하여 보이지 않는 것 처럼 사용하는 css 꼼수를 그대로 적용하였습니다.



## 시각자료
https://github.com/user-attachments/assets/000168d2-14fb-417f-83fe-e97bef751dea



## 체크리스트
- [x] 기능 명세를 작성하였나요?
- [x] 테스트 코드를 작성하였나요?

## 추가 논의사항
의현님이 설정해주신 프로젝트 환경에 대해 정확하게 이해를 하지는 못해서 잘못 설정한 곳이 있으면 피드백 부탁 드립니당 🙇🏻‍♂️