### PR TITLE
fix(ci): 타입 체크를 먼저 실행한 후에 빌드를 실행합니다.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       run: pnpm --filter="...[origin/${{ github.base_ref }}]" lint
     - name: 테스트
       run: pnpm --filter="...[origin/${{ github.base_ref }}]" test
-    - name: 빌드
-      run: pnpm --filter="...[origin/${{ github.base_ref }}]" build
     - name: 타입 체크
       run: pnpm --filter="...[origin/${{ github.base_ref }}]" typecheck
+    - name: 빌드
+      run: pnpm --filter="...[origin/${{ github.base_ref }}]" build


### PR DESCRIPTION
## 변경사항
- 빌드 후 타입 체크를 실행하면 dist 폴더도 불필요하게 타입을 검사하는 문제가 있어서 실행 순서를 조정했습니다.

## 시각자료
<!-- 참고할 수 있는 스크린샷이나 시각자료가 있으면 첨부해주세요. -->

## 체크리스트
- [ ] 기능 명세를 작성하였나요?
- [ ] 테스트 코드를 작성하였나요?

## 추가 논의사항
<!-- 추가로 알아야 할 참고사항이 있으면 적어주세요. -->
