### PR TITLE
feat(divider): Divider 컴포넌트 구현

### DIFF
--- a/packages/divider/.storybook/main.ts
+++ b/packages/divider/.storybook/main.ts
@@ -1,0 +1,16 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+export default {
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  addons: [
+    '@storybook/addon-onboarding',
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@chromatic-com/storybook',
+    '@storybook/addon-interactions',
+  ],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+} satisfies StorybookConfig;

--- a/packages/divider/.storybook/preview.ts
+++ b/packages/divider/.storybook/preview.ts
@@ -1,0 +1,5 @@
+import type { Preview } from '@storybook/react';
+
+export default {
+  tags: ['autodocs'],
+} satisfies Preview;

--- a/packages/divider/env.d.ts
+++ b/packages/divider/env.d.ts
@@ -1,0 +1,1 @@
+declare module '*.module.css';

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -36,7 +36,8 @@
     "storybook": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@sipe-team/typography": "workspace:*"
   },
   "peerDependencies": {
     "react": ">= 18"

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -28,6 +28,8 @@
     "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
     "@types/react": "^18.3.12",
     "happy-dom": "catalog:",
     "react": "^18.3.1",

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -9,7 +9,9 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -21,6 +23,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",
+    "@sipe-team/typography": "workspace:*",
     "@storybook/addon-essentials": "catalog:",
     "@storybook/addon-interactions": "catalog:",
     "@storybook/addon-links": "catalog:",
@@ -36,8 +39,7 @@
     "storybook": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:",
-    "@sipe-team/typography": "workspace:*"
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "react": ">= 18"
@@ -57,5 +59,8 @@
       }
     }
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "dependencies": {
+    "clsx": "^2.1.1"
+  }
 }

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@sipe-team/divider",
+  "description": "divider component for Sipe Design System",
+  "version": "0.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sipe-team/3-1_sds"
+  },
+  "type": "module",
+  "exports": "./src/index.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "build:storybook": "storybook build",
+    "dev:storybook": "storybook dev -p 6006",
+    "lint": "biome lint .",
+    "test": "vitest",
+    "typecheck": "tsc",
+    "prepack": "pnpm run build"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@storybook/addon-essentials": "catalog:",
+    "@storybook/addon-interactions": "catalog:",
+    "@storybook/addon-links": "catalog:",
+    "@storybook/blocks": "catalog:",
+    "@storybook/react": "catalog:",
+    "@storybook/react-vite": "catalog:",
+    "@storybook/test": "catalog:",
+    "@types/react": "^18.3.12",
+    "happy-dom": "catalog:",
+    "react": "^18.3.1",
+    "storybook": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "react": ">= 18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      }
+    }
+  },
+  "sideEffects": false
+}

--- a/packages/divider/src/Divider.module.css
+++ b/packages/divider/src/Divider.module.css
@@ -1,0 +1,15 @@
+.divider {
+  border: 0;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.horizontal.divider {
+  width: 100%;
+  height: 1px;
+}
+
+.vertical.divider {
+  width: 1px;
+  height: 100%;
+}

--- a/packages/divider/src/Divider.module.css
+++ b/packages/divider/src/Divider.module.css
@@ -2,6 +2,7 @@
   border: 0;
   margin: 0;
   flex-shrink: 0;
+  background-color: black;
 }
 
 .horizontal.divider {

--- a/packages/divider/src/Divider.stories.tsx
+++ b/packages/divider/src/Divider.stories.tsx
@@ -1,3 +1,4 @@
+import { Typography } from '@sipe-team/typography';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Divider } from './Divider';
 
@@ -11,4 +12,63 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+  render: () => (
+    <div
+      style={{
+        width: '300px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '48px',
+      }}
+    >
+      {/* 기본 가로 방향 */}
+      <section>
+        <Typography weight="bold" size={12}>
+          <h2>가로 구분선</h2>
+        </Typography>
+
+        <div>
+          <Divider />
+        </div>
+      </section>
+
+      {/* 기본 세로 방향 */}
+      <section>
+        <Typography weight="bold" size={12}>
+          <h2>세로 구분선</h2>
+        </Typography>
+
+        <div style={{ height: '50px', display: 'flex', alignItems: 'center' }}>
+          <Typography size={12}>좌</Typography>
+          <Divider orientation="vertical" style={{ margin: '0 16px' }} />
+          <Typography size={12}>우</Typography>
+        </div>
+      </section>
+
+      {/* 스타일 섹션 */}
+      <section>
+        <Typography weight="bold" size={12}>
+          <h2>스타일링</h2>
+        </Typography>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+          <div>
+            <Typography>default</Typography>
+            <Divider style={{ backgroundColor: '#E5E7EB' }} />
+          </div>
+
+          <div>
+            <Typography>colored</Typography>
+            <Divider style={{ backgroundColor: '#3B82F6' }} />
+          </div>
+
+          <div>
+            <Typography>thick</Typography>
+            <Divider style={{ backgroundColor: '#E5E7EB', height: '4px' }} />
+          </div>
+        </div>
+      </section>
+    </div>
+  ),
+};

--- a/packages/divider/src/Divider.stories.tsx
+++ b/packages/divider/src/Divider.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Divider } from './Divider';
+
+const meta = {
+  component: Divider,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof Divider>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/packages/divider/src/Divider.test.tsx
+++ b/packages/divider/src/Divider.test.tsx
@@ -1,5 +1,40 @@
-import { test } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { Divider } from './Divider';
+import styles from './divider.module.css';
 
-test.todo('orientation 속성이 없으면 가로 방향으로 그린다.');
-test.todo('orientation이 vertical이면 세로 방향으로 그린다.');
-test.todo('전달받은 style 속성이 컴포넌트에 적용된다.');
+describe('Divider', () => {
+  test('orientation 속성이 없으면 가로 방향으로 그린다.', () => {
+    render(<Divider />);
+
+    const divider = screen.getByRole('separator');
+
+    expect(divider).toHaveAttribute('aria-orientation', 'horizontal');
+    expect(divider).toHaveClass(styles.horizontal);
+  });
+
+  test('orientation이 vertical이면 세로 방향으로 그린다.', () => {
+    render(<Divider orientation="vertical" />);
+
+    const divider = screen.getByRole('separator');
+
+    expect(divider).toHaveAttribute('aria-orientation', 'vertical');
+    expect(divider).toHaveClass(styles.vertical);
+  });
+
+  test('전달받은 style 속성이 컴포넌트에 적용된다.', () => {
+    const testStyle = {
+      backgroundColor: 'red',
+      margin: '8px',
+    };
+
+    render(<Divider style={testStyle} />);
+
+    const divider = screen.getByRole('separator');
+
+    expect(divider).toHaveStyle({
+      backgroundColor: 'red',
+      margin: '8px',
+    });
+  });
+});

--- a/packages/divider/src/Divider.test.tsx
+++ b/packages/divider/src/Divider.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
 import { Divider } from './Divider';
-import styles from './divider.module.css';
+import styles from './Divider.module.css';
 
 describe('Divider', () => {
   test('orientation 속성이 없으면 가로 방향으로 그린다.', () => {

--- a/packages/divider/src/Divider.test.tsx
+++ b/packages/divider/src/Divider.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
 import { Divider } from './Divider';
-import styles from './Divider.module.css';
 
 describe('Divider', () => {
   test('orientation 속성이 없으면 가로 방향으로 그린다.', () => {
@@ -10,7 +9,10 @@ describe('Divider', () => {
     const divider = screen.getByRole('separator');
 
     expect(divider).toHaveAttribute('aria-orientation', 'horizontal');
-    expect(divider).toHaveClass(styles.horizontal);
+    expect(divider).toHaveStyle({
+      width: '100%',
+      height: '1px',
+    });
   });
 
   test('orientation이 vertical이면 세로 방향으로 그린다.', () => {
@@ -19,7 +21,10 @@ describe('Divider', () => {
     const divider = screen.getByRole('separator');
 
     expect(divider).toHaveAttribute('aria-orientation', 'vertical');
-    expect(divider).toHaveClass(styles.vertical);
+    expect(divider).toHaveStyle({
+      width: '1px',
+      height: '100%',
+    });
   });
 
   test('전달받은 style 속성이 컴포넌트에 적용된다.', () => {

--- a/packages/divider/src/Divider.test.tsx
+++ b/packages/divider/src/Divider.test.tsx
@@ -1,0 +1,5 @@
+import { test } from 'vitest';
+
+test.todo('orientation 속성이 없으면 가로 방향으로 그린다.');
+test.todo('orientation이 vertical이면 세로 방향으로 그린다.');
+test.todo('전달받은 style 속성이 컴포넌트에 적용된다.');

--- a/packages/divider/src/Divider.tsx
+++ b/packages/divider/src/Divider.tsx
@@ -1,0 +1,3 @@
+export function Divider() {
+  return <div>Component</div>;
+}

--- a/packages/divider/src/Divider.tsx
+++ b/packages/divider/src/Divider.tsx
@@ -1,3 +1,17 @@
-export function Divider() {
-  return <div>Component</div>;
+import type { CSSProperties } from 'react';
+import styles from './Divider.module.css';
+
+interface DividerProps {
+  orientation?: 'horizontal' | 'vertical';
+  style?: CSSProperties;
+}
+
+export function Divider({ orientation = 'horizontal', style }: DividerProps) {
+  return (
+    <hr
+      aria-orientation={orientation}
+      className={`${styles[orientation]} ${styles.divider}`}
+      style={style}
+    />
+  );
 }

--- a/packages/divider/src/Divider.tsx
+++ b/packages/divider/src/Divider.tsx
@@ -1,17 +1,22 @@
-import type { CSSProperties } from 'react';
+import { clsx as cx } from 'clsx';
+import { type ComponentProps, forwardRef } from 'react';
 import styles from './Divider.module.css';
 
-interface DividerProps {
+interface DividerProps extends ComponentProps<'hr'> {
   orientation?: 'horizontal' | 'vertical';
-  style?: CSSProperties;
 }
 
-export function Divider({ orientation = 'horizontal', style }: DividerProps) {
+export const Divider = forwardRef(function Divider({
+  orientation = 'horizontal',
+  ...props
+}: DividerProps) {
   return (
     <hr
+      {...props}
       aria-orientation={orientation}
-      className={`${styles[orientation]} ${styles.divider}`}
-      style={style}
+      className={cx(styles[orientation], styles.divider, props.className)}
     />
   );
-}
+});
+
+Divider.displayName = 'Divider';

--- a/packages/divider/src/index.ts
+++ b/packages/divider/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Divider';

--- a/packages/divider/tsconfig.json
+++ b/packages/divider/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/divider/tsup.config.ts
+++ b/packages/divider/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  clean: true,
+  dts: true,
+  format: ['esm', 'cjs'],
+});

--- a/packages/divider/vitest.config.ts
+++ b/packages/divider/vitest.config.ts
@@ -3,7 +3,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'happy-dom',
+    globals: true,
     passWithNoTests: true,
+    setupFiles: './vitest.setup.ts',
     watch: false,
+    css: true,
   },
 });

--- a/packages/divider/vitest.config.ts
+++ b/packages/divider/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    passWithNoTests: true,
+    watch: false,
+  },
+});

--- a/packages/divider/vitest.setup.ts
+++ b/packages/divider/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,60 @@ importers:
         specifier: 'catalog:'
         version: 2.1.4(@types/node@22.8.1)(happy-dom@15.7.4)
 
+  packages/divider:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 1.9.4
+      '@storybook/addon-essentials':
+        specifier: 'catalog:'
+        version: 8.3.6(storybook@8.3.6)
+      '@storybook/addon-interactions':
+        specifier: 'catalog:'
+        version: 8.3.6(storybook@8.3.6)
+      '@storybook/addon-links':
+        specifier: 'catalog:'
+        version: 8.3.6(react@18.3.1)(storybook@8.3.6)
+      '@storybook/blocks':
+        specifier: 'catalog:'
+        version: 8.3.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)
+      '@storybook/react':
+        specifier: 'catalog:'
+        version: 8.3.6(@storybook/test@8.3.6(storybook@8.3.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)(typescript@5.6.3)
+      '@storybook/react-vite':
+        specifier: 'catalog:'
+        version: 8.3.6(@storybook/test@8.3.6(storybook@8.3.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.2)(storybook@8.3.6)(typescript@5.6.3)(vite@5.4.10(@types/node@22.8.1))
+      '@storybook/test':
+        specifier: 'catalog:'
+        version: 8.3.6(storybook@8.3.6)
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: ^16.0.1
+        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.12
+      happy-dom:
+        specifier: 'catalog:'
+        version: 15.7.4
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      storybook:
+        specifier: 'catalog:'
+        version: 8.3.6
+      tsup:
+        specifier: 'catalog:'
+        version: 8.3.5(jiti@2.3.3)(postcss@8.4.47)(typescript@5.6.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.6.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.4(@types/node@22.8.1)(happy-dom@15.7.4)
+
   packages/skeleton:
     dependencies:
       '@radix-ui/react-slot':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 1.9.4
+      '@sipe-team/typography':
+        specifier: workspace:*
+        version: link:../typography
       '@storybook/addon-essentials':
         specifier: 'catalog:'
         version: 8.3.6(storybook@8.3.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,10 @@ importers:
         version: 2.1.4(@types/node@22.8.1)(happy-dom@15.7.4)
 
   packages/divider:
+    dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
     devDependencies:
       '@biomejs/biome':
         specifier: 'catalog:'


### PR DESCRIPTION
## 변경사항
<!-- 변경사항에 대해 간단히 설명해주세요. -->
- 간단하게 구분선을 그리는 컴포넌트입니다.
- color, size 등을 prop으로 뚫을까 하다가 구분선을 사용할 때 보통 margin, padding 등을 같이 쓰다보니 style을 받아서 사용자가 다 넣을 수 있게 했습니다. (radix와 MUI 인터페이스 참고)

## 시각자료
<!-- 참고할 수 있는 스크린샷이나 시각자료가 있으면 첨부해주세요. -->
![screenshot](https://github.com/user-attachments/assets/99d8c39e-eeb2-4294-9306-6e7479acd171)

## 체크리스트
- [x] 기능 명세를 작성하였나요?
- [x] 테스트 코드를 작성하였나요?

## 추가 논의사항
<!-- 추가로 알아야 할 참고사항이 있으면 적어주세요. -->
- 제안주실 거나 이상한 점 모두 말해주세요!