### PR TITLE
feat: 패키지 배포 자동화 구성

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@sipe-team/component"]
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: pnpm 설치
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Node.js 환경 설정
+        uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version-file: .nvmrc
+          registry-url: https://npm.pkg.github.com
+          scope: "@sipe-team"
+      - name: 의존성 설치
+        run: pnpm install
+      - name: Create Release Pull Request or Publish to Github Package Registry
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: pnpm changeset version
+          publish: pnpm changeset publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.templates/component/package.json
+++ b/.templates/component/package.json
@@ -41,6 +41,7 @@
   },
   "publishConfig": {
     "access": "public",
+    "registry": "https://npm.pkg.github.com",
     "exports": {
       ".": {
         "import": {

--- a/packages/Input/package.json
+++ b/packages/Input/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@sipe-team/component",
-  "description": "component for Sipe Design System",
+  "name": "@sipe-team/input",
+  "description": "Input component for Sipe Design System",
   "version": "0.0.0",
   "license": "MIT",
   "repository": {
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -50,6 +48,7 @@
   },
   "publishConfig": {
     "access": "public",
+    "registry": "https://npm.pkg.github.com",
     "exports": {
       ".": {
         "import": {

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -46,6 +44,7 @@
   },
   "publishConfig": {
     "access": "public",
+    "registry": "https://npm.pkg.github.com",
     "exports": {
       ".": {
         "import": {

--- a/packages/typography/CHANGELOG.md
+++ b/packages/typography/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @sipe-team/typography
+
+## 0.0.1
+
+### Patch Changes
+
+- chore: bump version

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/typography",
   "description": "Typography component for Sipe Design System",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -48,6 +48,7 @@
   },
   "publishConfig": {
     "access": "public",
+    "registry": "https://npm.pkg.github.com",
     "exports": {
       ".": {
         "import": {


### PR DESCRIPTION
## 변경사항
- changeset을 활용하여 패키지 배포 자동화
- 우선은 npm 대신 GPR(github package registry)에 publish 하도록 설정
    - npm은 배포한 패키지를 지우기 어려운데 gpr은 삭제가 자유로움 
- [배포한 패키지는 이렇게 올라감](https://github.com/sipe-team/3-1_sds/pkgs/npm/typography)

## 시각자료
<!-- 참고할 수 있는 스크린샷이나 시각자료가 있으면 첨부해주세요. -->

## 체크리스트
- [ ] 기능 명세를 작성하였나요?
- [ ] 테스트 코드를 작성하였나요?

## 추가 논의사항
<!-- 추가로 알아야 할 참고사항이 있으면 적어주세요. -->
