### PR TITLE
fix(test): add exclude in root vitest.config.ts

### DIFF
--- a/packages/Input/src/Input.module.css.d.ts
+++ b/packages/Input/src/Input.module.css.d.ts
@@ -1,7 +1,0 @@
-
-declare const styles: {
-  readonly "input-wrapper": string;
-  readonly "input": string;
-  readonly "input-action": string;
-};
-export default styles;

--- a/packages/Input/src/env.d.ts
+++ b/packages/Input/src/env.d.ts
@@ -1,0 +1,1 @@
+declare module '*.module.css';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,15 +12,12 @@ export default defineConfig({
         '.storybook/*',
         'packages/*/src/*.stories.tsx',
         'packages/*/src/*.test.*',
+        'packages/*/src/index.ts',
         'packages/*/src/*.d.ts',
-        'packages/*/src/*.ts',
-        'packages/*/src/*/*.ts',
-        
         'packages/*/.storybook/*',
         'packages/*/coverage/*',
         'packages/*/vitest.setup.ts',
         'packages/*/dist/*',
-
         'packages/*/*.config.ts',
         'packages/*/*.d.ts',
         '*.ts',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,25 @@ export default defineConfig({
     globals: true,
     passWithNoTests: true,
     watch: false,
+    coverage: {
+      exclude: [
+        '.templates/*',
+        '.storybook/*',
+        'packages/*/src/*.stories.tsx',
+        'packages/*/src/*.test.*',
+        'packages/*/src/*.d.ts',
+        'packages/*/src/*.ts',
+        'packages/*/src/*/*.ts',
+        
+        'packages/*/.storybook/*',
+        'packages/*/coverage/*',
+        'packages/*/vitest.setup.ts',
+        'packages/*/dist/*',
+
+        'packages/*/*.config.ts',
+        'packages/*/*.d.ts',
+        '*.ts',
+      ],
+    },
   },
 });


### PR DESCRIPTION
## 변경사항

- 다른 코드랑 컨벤션 맞추기위해 Input에 `.d.ts`  수정
- test coverage exclude 추가 

## 시각자료

|AS-IS|TO-BE|
|:-:|:-:|
|<img width="529" alt="Screenshot 2024-12-18 at 12 47 23 AM" src="https://github.com/user-attachments/assets/1ea182a0-796d-4549-b501-9978e0da1634" />|<img width="572" alt="Screenshot 2024-12-18 at 12 52 40 AM" src="https://github.com/user-attachments/assets/81d0c22f-fd9a-4e44-9184-1820777faa59" />|

## 체크리스트
- [ ] 기능 명세를 작성하였나요?
- [ ] 테스트 코드를 작성하였나요?

## 추가 논의사항
<!-- 추가로 알아야 할 참고사항이 있으면 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **버그 수정**
	- CSS 모듈 스타일에 대한 TypeScript 선언 파일이 삭제되었습니다.
  
- **새로운 기능**
	- CSS 모듈을 가져올 수 있도록 TypeScript 정의 파일에 새로운 선언이 추가되었습니다.
  
- **구성 변경**
	- 테스트 구성에서 커버리지 설정이 추가되어 특정 파일 패턴이 커버리지 보고서에서 제외됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->