### PR TITLE
fix(pnpm-lock): update storybook version from 8.4.5 to 8.4.6

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2543,8 +2543,8 @@ packages:
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
-  storybook@8.4.5:
-    resolution: {integrity: sha512-9tfgabXnMibYp3SvoaJXXMD63Pw0SA9Hnf5v6TxysCYZs4DZ/04fAkK+9RW+K4C5JkV83qXMMlrsPj766R47fg==}
+  storybook@8.4.6:
+    resolution: {integrity: sha512-J6juZSZT2u3PUW0QZYZZYxBq6zU5O0OrkSgkMXGMg/QrS9to9IHmt4FjEMEyACRbXo8POcB/fSXa3VpGe7bv3g==}
     hasBin: true
     peerDependencies:
       prettier: ^2 || ^3
@@ -4870,7 +4870,7 @@ snapshots:
 
   std-env@3.8.0: {}
 
-  storybook@8.4.5(prettier@2.8.8):
+  storybook@8.4.6(prettier@2.8.8):
     dependencies:
       '@storybook/core': 8.4.6(prettier@2.8.8)
     optionalDependencies:


### PR DESCRIPTION
pnpm install --no-frozen-lockfile

## 변경사항
switch pr을 merge하면서 pnpm-lock.yaml에 conflict가 발생했고,
수정했으나 크로마틱 배포 시에 의존성 설치 단계에서 에러가 발생했습니다.

`pnpm install --no-frozen-lockfile` 명령어를 사용해서 해결하였습니다.

## 시각자료
![image](https://github.com/user-attachments/assets/c2b7a831-5314-47ad-aa37-e731245e70fc)

![image](https://github.com/user-attachments/assets/afbd8523-e174-4466-ae8d-8307a14e5130)

## 추가 논의사항
- 없음
